### PR TITLE
Fix userId missing from join session API response

### DIFF
--- a/client-app/src/common/ApiService.js
+++ b/client-app/src/common/ApiService.js
@@ -34,6 +34,7 @@ const ApiService = {
 
     return {
       votingOptions: data.votingOptions,
+      userId: data.userId,
       accessToken: {
         token: data.accessToken.token,
         type: data.accessToken.type,


### PR DESCRIPTION
## Summary
- ensure ApiService.joinSession includes `userId`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6894de0ae860832ba48db70f8db6589a